### PR TITLE
Update Oragono/Ergo in family-tree

### DIFF
--- a/family-tree.txt
+++ b/family-tree.txt
@@ -134,7 +134,8 @@ sorted alphabetically with "ircd-" prefix removed
     ircd-micro {TS6}
         tethys (<-ircd-micro 0.1)
     ngIRCd {RFC2812}
-    Oragono
+    Ergonomadic
+        Ergo (<-Oragono)
     pircd
     Pure-IRCd (in VB)
         ignitionServer

--- a/family-tree.txt
+++ b/family-tree.txt
@@ -126,6 +126,8 @@ sorted alphabetically with "ircd-" prefix removed
     ConferenceRoom
     csircd {TS5}
     DarkIRCd {TS6}
+    Ergonomadic
+        Ergo (<-Oragono)
     InspIRCd {InspIRCd TS6}
         InspIRCd+Xynotyro
             ircd-sakura [<-InspIRCd-1.1.11+Xynotyro]
@@ -134,8 +136,6 @@ sorted alphabetically with "ircd-" prefix removed
     ircd-micro {TS6}
         tethys (<-ircd-micro 0.1)
     ngIRCd {RFC2812}
-    Ergonomadic
-        Ergo (<-Oragono)
     pircd
     Pure-IRCd (in VB)
         ignitionServer


### PR DESCRIPTION
Original IRCd was Ergonomadic:
  https://github.com/jlatt/ergonomadic
which ended up getting maintained by ehuber here:
  https://github.com/edmund-huber/ergonomadic
And was forked by me into Oragono. We just changed names to Ergo though, https://github.com/ergochat/ergo